### PR TITLE
Palette API call + general refactoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@
 !app/public
 !app/src
 !server/*.mjs
+!server/routers
 !server/package*.json

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1277,11 +1277,6 @@
         }
       }
     },
-    "@excalidraw/excalidraw": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@excalidraw/excalidraw/-/excalidraw-0.7.0.tgz",
-      "integrity": "sha512-D1yMXhOjWjCJIXT0puZD2QaGQ28QN2DNrVUQTsOouhPSELwhFoM7Exg/ulSwkLBI2l2KN7m39+2tj6QVijv4Sg=="
-    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11750,6 +11750,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-router": {
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.0-beta.0.tgz",
+      "integrity": "sha512-VgMdfpVcmFQki/LZuLh8E/MNACekDetz4xqft+a6fBZvvJnVqKbLqebF7hyoawGrV1HcO5tVaUang2Og4W2j1Q==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.0-beta.0.tgz",
+      "integrity": "sha512-36yNNGMT8RB9FRPL9nKJi6HKDkgOakU+o/2hHpSzR6e37gN70MpOU6QQlmif4oAWWBwjyGc3ZNOMFCsFuHUY5w==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "react-router": "6.0.0-beta.0"
+      }
+    },
     "react-scripts": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.3.tgz",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1726,17 +1726,6 @@
         }
       }
     },
-    "@reach/router": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-      "requires": {
-        "create-react-context": "0.3.0",
-        "invariant": "^2.2.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -4264,15 +4253,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
       }
     },
     "cross-spawn": {
@@ -6863,11 +6843,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -7006,6 +6981,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "history": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
+      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -7490,14 +7473,6 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "ip": {
@@ -11740,11 +11715,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -14647,14 +14617,6 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,8 @@
     "react-canvas-draw": "^1.1.1",
     "react-colorful": "^5.1.4",
     "react-dom": "^17.0.1",
+    "react-router": "^6.0.0-beta.0",
+    "react-router-dom": "^6.0.0-beta.0",
     "react-scripts": "^4.0.3",
     "web-vitals": "^1.0.1"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -30,10 +30,10 @@
   "proxy": "http://localhost:4000",
   "dependencies": {
     "@auth0/auth0-react": "^1.4.0",
-    "@reach/router": "^1.3.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^13.0.2",
+    "history": "^5.0.0",
     "react": "^17.0.1",
     "react-canvas-draw": "^1.1.1",
     "react-colorful": "^5.1.4",

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
   "proxy": "http://localhost:4000",
   "dependencies": {
     "@auth0/auth0-react": "^1.4.0",
-    "@excalidraw/excalidraw": "^0.7.0",
     "@reach/router": "^1.3.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/app/src/App.js
+++ b/app/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useAuth0 } from '@auth0/auth0-react';
-import { Router } from '@reach/router';
+import { Routes, Route } from 'react-router-dom';
 
 import Loading from './components/Loading';
 import Navbar from './components/Navbar';
@@ -20,10 +20,10 @@ export default function App() {
   return (
     <div className="App">
       <Navbar />
-      <Router>
-        <Main path="/" />
-        <History path="/history" />
-      </Router>
+      <Routes>
+        <Route path="/" element={<Main />} />
+        <Route path="history" element={<History />} />
+      </Routes>
     </div>
   );
 }

--- a/app/src/components/Navbar.js
+++ b/app/src/components/Navbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 
 import LoginItems from './navbar/LoginItems';
 

--- a/app/src/components/navbar/HistoryBtn.js
+++ b/app/src/components/navbar/HistoryBtn.js
@@ -1,14 +1,15 @@
 import React from 'react';
 
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 
 export default function HistoryBtn({ isAuthenticated }) {
   if (!isAuthenticated) {
+    // TODO: Show, but route to auth page instead
     return <></>;
   }
   return (
     <button className="history-btn">
-      <Link to="/history">Share History</Link>
+      <Link to="history">Share History</Link>
     </button>
   );
 }

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -2,19 +2,22 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Auth0Provider } from '@auth0/auth0-react';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 ReactDOM.render(
   <React.StrictMode>
-    <Auth0Provider
-      domain={process.env.REACT_APP_AUTH0_DOMAIN}
-      clientId={process.env.REACT_APP_AUTH0_CLIENT_ID}
-      redirectUri={window.location.origin}
-    >
-      <App />
-    </Auth0Provider>
+    <BrowserRouter>
+      <Auth0Provider
+        domain={process.env.REACT_APP_AUTH0_DOMAIN}
+        clientId={process.env.REACT_APP_AUTH0_CLIENT_ID}
+        redirectUri={window.location.origin}
+      >
+        <App />
+      </Auth0Provider>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),
 );

--- a/server/routers/images.mjs
+++ b/server/routers/images.mjs
@@ -1,0 +1,13 @@
+import express from 'express';
+
+// handles processes relating to images
+const imgHandler = express.Router();
+imgHandler.use(express.json());
+
+imgHandler.post('/', async (req, res) => {
+  const { imgDataURL } = req.body;
+
+  res.json({ hi: 'there', imgURL: imgDataURL.length });
+});
+
+export default imgHandler;

--- a/server/routers/palette.mjs
+++ b/server/routers/palette.mjs
@@ -1,0 +1,22 @@
+import express from 'express';
+import got from 'got';
+
+const paletteRouter = express.Router();
+paletteRouter.use(express.json());
+
+paletteRouter.get('/', async (req, res) => {
+  // Colormind has a random assort of color models each day
+  const colorModels = await got
+    .get('http://colormind.io/list/', { responseType: 'json' })
+    .then((result) => result.body.result);
+  const randomModel = colorModels[Math.floor(Math.random() * colorModels.length)];
+
+  const { body } = await got.post('http://colormind.io/api/',
+    {
+      json: { model: randomModel },
+      responseType: 'json',
+    });
+  res.json(body.result);
+});
+
+export default paletteRouter;

--- a/server/routers/palette.mjs
+++ b/server/routers/palette.mjs
@@ -6,16 +6,25 @@ paletteRouter.use(express.json());
 
 paletteRouter.get('/', async (req, res) => {
   // Colormind has a random assort of color models each day
+  // 'default' + 'ui' are always available models
   const colorModels = await got
     .get('http://colormind.io/list/', { responseType: 'json' })
-    .then((result) => result.body.result);
+    .then((result) => result.body.result)
+    .catch((err) => {
+      // '/list' is down for 30 sec daily
+      console.error(err);
+      return ['ui', 'default'];
+    });
+  // pick a random model from returned list
   const randomModel = colorModels[Math.floor(Math.random() * colorModels.length)];
 
+  // generates palette
   const { body } = await got.post('http://colormind.io/api/',
     {
       json: { model: randomModel },
       responseType: 'json',
     });
+
   res.json(body.result);
 });
 

--- a/server/routers/palette.mjs
+++ b/server/routers/palette.mjs
@@ -1,10 +1,10 @@
 import express from 'express';
 import got from 'got';
 
-const paletteRouter = express.Router();
-paletteRouter.use(express.json());
+const paletteGenerator = express.Router();
+paletteGenerator.use(express.json());
 
-paletteRouter.get('/', async (req, res) => {
+paletteGenerator.get('/', async (req, res) => {
   // Colormind has a random assort of color models each day
   // 'default' + 'ui' are always available models
   const colorModels = await got
@@ -28,4 +28,4 @@ paletteRouter.get('/', async (req, res) => {
   res.json(body.result);
 });
 
-export default paletteRouter;
+export default paletteGenerator;

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -4,7 +4,7 @@ import mime from 'mime-types';
 
 // only works with specifying extension?
 import imgHandler from './routers/images.mjs';
-import paletteRouter from './routers/palette.mjs';
+import paletteGenerator from './routers/palette.mjs';
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -13,7 +13,7 @@ const port = process.env.PORT || 4000;
 app.use('/api/upload', imgHandler);
 
 // handles processes relating to color palettes
-app.use('/api/colors', paletteRouter);
+app.use('/api/colors', paletteGenerator);
 
 // By @gsong
 // eslint-disable-next-line no-unused-expressions

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -1,23 +1,16 @@
+/* eslint-disable import/extensions */
 import express from 'express';
 import mime from 'mime-types';
 
-// requires .js/.mjs but unsure why
-// eslint-disable-next-line import/extensions
+// only works with specifying extension?
+import imgHandler from './routers/images.mjs';
 import paletteRouter from './routers/palette.mjs';
 
 const app = express();
 const port = process.env.PORT || 4000;
 
 // handles processes relating to images
-const imgHandler = express.Router();
-imgHandler.use(express.json());
 app.use('/api/upload', imgHandler);
-
-imgHandler.post('/', async (req, res) => {
-  const { imgDataURL } = req.body;
-
-  res.json({ hi: 'there', imgURL: imgDataURL.length });
-});
 
 // handles processes relating to color palettes
 app.use('/api/colors', paletteRouter);

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -1,6 +1,9 @@
 import express from 'express';
-import got from 'got';
 import mime from 'mime-types';
+
+// requires .js/.mjs but unsure why
+// eslint-disable-next-line import/extensions
+import paletteRouter from './routers/palette.mjs';
 
 const app = express();
 const port = process.env.PORT || 4000;
@@ -17,26 +20,7 @@ imgHandler.post('/', async (req, res) => {
 });
 
 // handles processes relating to color palettes
-const colors = express.Router();
-colors.use(express.json());
-// TODO: move this router as its own file + importing it
-app.use('/api/colors', colors);
-
-// generates a color palette from colormind.io
-colors.get('/', async (req, res) => {
-  // Colormind has a random assort of color models each day
-  const colorModels = await got
-    .get('http://colormind.io/list/', { responseType: 'json' })
-    .then((result) => result.body.result);
-  const randomModel = colorModels[Math.floor(Math.random() * colorModels.length)];
-
-  const { body } = await got.post('http://colormind.io/api/',
-    {
-      json: { model: randomModel },
-      responseType: 'json',
-    });
-  res.json(body.result);
-});
+app.use('/api/colors', paletteRouter);
 
 // By @gsong
 // eslint-disable-next-line no-unused-expressions

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -2,7 +2,6 @@
 import express from 'express';
 import mime from 'mime-types';
 
-// only works with specifying extension?
 import imgHandler from './routers/images.mjs';
 import paletteGenerator from './routers/palette.mjs';
 


### PR DESCRIPTION
Organized the image handling + color palette generation on the backend into their own modules for ease of readability. This should hopefully make it easier to setup and debug extra things later like AWS.

I also did some package + code cleanup, and chose to replace `@reach/router` with `react-router` v6, which absorbed reach router anyways. The purpose of reach router was that it is a lighter package, but v6 supports that too now with tree-shaking. When doing research into the package, it seems like people are having stable experiences with it, despite it being in beta stage technically. On some Auth0 tutorials they mention react-router parts, so that's another reason why I'm choosing to switch, for ease and consistency.