### PR TITLE
Registered users can refresh the share-url

### DIFF
--- a/app/src/apiClient.js
+++ b/app/src/apiClient.js
@@ -68,11 +68,12 @@ export const getImgHistory = async (userId) => {
 };
 
 export const renewShareUrl = async (userId, fileName) => {
-  const { imgUrl, startTime } = await fetch(`/api/user/share-url?fileName=${fileName}&id=${userId}`);
+  const { imgUrl, startTime } = await fetch(`/api/user/share-url?fileName=${fileName}&id=${userId}`).then((out) => out.json());
 
   if (shareTimeExpired(startTime)) {
     // generate a new one, and replace it in the db
-    const { shareUrl } = await fetch(`/api/image/sign-s3-share?fileName=${fileName}`);
+    const { shareUrl } = await fetch(`/api/image/sign-s3-share?fileName=${fileName}`)
+      .then((out) => out.json());
 
     //  replace it in the db
     const { newStartTime } = await fetch('/api/user/share-url',
@@ -81,7 +82,9 @@ export const renewShareUrl = async (userId, fileName) => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ fileName, userId, shareUrl }),
+        body: JSON.stringify({
+          fileName, userId, shareUrl,
+        }),
       });
 
     return { url: shareUrl, time: newStartTime };

--- a/app/src/apiClient.js
+++ b/app/src/apiClient.js
@@ -8,7 +8,7 @@ export const uploadImg = async (imgDataURL, user) => {
   const { fileName, shareUrl } = await signedImg(imgDataURL);
 
   if (user) {
-    addUserImg(fileName, user);
+    addUserImg(fileName, user, shareUrl);
   }
 
   return shareUrl;
@@ -45,7 +45,7 @@ const signedUpload = async (imgDataURL, signedURL) => {
 };
 
 // Add user's new image to their image_history record
-const addUserImg = async (fileName, user) => {
+const addUserImg = async (fileName, user, shareUrl) => {
   const { url24Hr } = await fetch(`/api/image/sign-s3-share-user?fileName=${fileName}`)
     .then((out) => out.json());
 
@@ -55,7 +55,9 @@ const addUserImg = async (fileName, user) => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ fileName, user, url24Hr }),
+      body: JSON.stringify({
+        fileName, user, shareUrl, url24Hr,
+      }),
     });
 };
 

--- a/app/src/apiClient.js
+++ b/app/src/apiClient.js
@@ -4,6 +4,7 @@ export const getColors = async () => {
   return res.json();
 };
 
+// Directs all images processes and return shareable url
 export const uploadImg = async (imgDataURL, user) => {
   const { fileName, shareUrl } = await signedImg(imgDataURL);
 
@@ -62,7 +63,6 @@ const addUserImg = async (fileName, user, shareUrl) => {
 };
 
 export const getImgHistory = async (userId) => {
-  // TODO: needs to be made more secure, via token check?
   const history = await fetch(`/api/user/history?id=${userId}`);
   return history.json();
 };

--- a/app/src/components/ImgCard.js
+++ b/app/src/components/ImgCard.js
@@ -27,11 +27,17 @@ const useStyles = makeStyles({
 });
 
 export default function ImgCard({
-  name, url, timeCreated, refreshUrl,
+  fileName, cardUrl, timeCreated, shareUrl, sharedAtTime, user,
 }) {
-  const refreshClick = (e) => {
+  const [activeShareUrl, setActiveShareUrl] = React.useState(shareUrl);
+
+  const refreshUrl = async (e) => {
     e.preventDefault();
-    refreshUrl();
+
+    if (user) {
+      // renew url
+      // set it to active share url
+    }
   };
 
   // TODO: configure time display
@@ -45,18 +51,23 @@ export default function ImgCard({
           className={classes.media}
           alt="A Scribble"
           height="140"
-          image={url}
-          title={name}
+          image={cardUrl}
+          title={fileName}
         />
         <CardContent>
           <Typography variant="body2" component="p">
             Time created:
             {timeCreated}
           </Typography>
+          <Typography variant="body2" component="p">
+            Share it:
+            <a href={activeShareUrl}>click</a>
+            {/* time remaining here */}
+          </Typography>
         </CardContent>
       </CardActionArea>
       <CardActions className={classes.buttons}>
-        <Button size="medium" color="primary" onClick={(e) => refreshClick(e)}>
+        <Button size="medium" color="primary" onClick={(e) => refreshUrl(e)}>
           Share
         </Button>
         {/* <Button size="medium" color="primary">

--- a/app/src/components/ImgCard.js
+++ b/app/src/components/ImgCard.js
@@ -9,6 +9,8 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 
+import { renewShareUrl } from '../apiClient';
+
 const useStyles = makeStyles({
   root: {
     maxWidth: 345,
@@ -35,8 +37,8 @@ export default function ImgCard({
     e.preventDefault();
 
     if (user) {
-      // renew url
-      // set it to active share url
+      const { url, time } = await renewShareUrl(user.sub, fileName);
+      setActiveShareUrl(url);
     }
   };
 

--- a/app/src/components/ImgCard.js
+++ b/app/src/components/ImgCard.js
@@ -44,7 +44,7 @@ export default function ImgCard({
     }
   };
 
-  // TODO: configure time display
+  // TODO: Stylize time display
   const classes = useStyles();
 
   return (

--- a/app/src/components/ImgCard.js
+++ b/app/src/components/ImgCard.js
@@ -32,6 +32,7 @@ export default function ImgCard({
   fileName, cardUrl, timeCreated, shareUrl, sharedAtTime, user,
 }) {
   const [activeShareUrl, setActiveShareUrl] = React.useState(shareUrl);
+  const [activeUrlTime, setActiveUrlTime] = React.useState(sharedAtTime);
 
   const refreshUrl = async (e) => {
     e.preventDefault();
@@ -39,6 +40,7 @@ export default function ImgCard({
     if (user) {
       const { url, time } = await renewShareUrl(user.sub, fileName);
       setActiveShareUrl(url);
+      setActiveUrlTime(time);
     }
   };
 
@@ -63,8 +65,12 @@ export default function ImgCard({
           </Typography>
           <Typography variant="body2" component="p">
             Share it:
+            { ' ' }
             <a href={activeShareUrl}>click</a>
-            {/* time remaining here */}
+            <br />
+            Active since
+            {' '}
+            { activeUrlTime }
           </Typography>
         </CardContent>
       </CardActionArea>
@@ -72,9 +78,6 @@ export default function ImgCard({
         <Button size="medium" color="primary" onClick={(e) => refreshUrl(e)}>
           Share
         </Button>
-        {/* <Button size="medium" color="primary">
-          Delete
-        </Button> */}
       </CardActions>
     </Card>
   );

--- a/app/src/components/UserImgs.js
+++ b/app/src/components/UserImgs.js
@@ -11,11 +11,6 @@ export default function ImgHistory() {
 
   const { user, isAuthenticated } = useAuth0();
 
-  const refreshUrl = async (url) => {
-    // TODO: configure new signed url
-    console.log('Refresh request in process');
-  };
-
   React.useEffect(() => {
     const getUserImgHistory = async () => {
       let id = '';
@@ -35,10 +30,12 @@ export default function ImgHistory() {
         images.map((image) => (
           <ImgCard
             key={image.img_id}
-            name={image.img_name}
-            url={image.img_url}
+            fileName={image.img_name}
+            cardUrl={image.card_img_url}
             timeCreated={image.time_created}
-            refreshUrl={refreshUrl}
+            shareUrl={image.share_img_url}
+            sharedAtTime={image.share_start_time}
+            user={user}
           />
         ))
       }

--- a/pg/seed.pgsql
+++ b/pg/seed.pgsql
@@ -5,7 +5,7 @@
 -- Dumped from database version 13.2
 -- Dumped by pg_dump version 13.2
 
--- Started on 2021-05-20 14:50:24
+-- Started on 2021-05-20 19:30:08
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -43,10 +43,12 @@ SET default_table_access_method = heap;
 
 CREATE TABLE public.images (
     img_id integer NOT NULL,
-    user_id text,
+    user_id text NOT NULL,
     img_name text,
     time_created timestamp without time zone,
-    img_url character varying
+    card_img_url text,
+    share_img_url text,
+    share_start_time timestamp without time zone
 );
 
 
@@ -122,14 +124,12 @@ ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_
 -- Data for Name: images; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY public.images (img_id, user_id, img_name, time_created, img_url) FROM stdin;
-2	scribbler|123	scribbler-sample-1.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/1.png
-3	scribbler|123	scribbler-sample-2.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/2.png
-4	scribbler|123	scribbler-sample-3.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/3.png
-5	scribbler|123	scribbler-sample-4.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621210456/scribbler-samples/4.png
-6	scribbler|123	scribbler-sample-5.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621210678/scribbler-samples/5.png
-7	auth0|60a197e2cbc3e700700e2352	scribble_QqyeW8P7PdNbLBxu01D-M.png	2021-05-09 20:31:33.709636	scribble_QqyeW8P7PdNbLBxu01D-M.png
-8	auth0|60a197e2cbc3e700700e2352	UzAeBf3jlJfBv2NX0nKc9.png	2021-05-09 20:31:33.709636	UzAeBf3jlJfBv2NX0nKc9.png
+COPY public.images (img_id, user_id, img_name, time_created, card_img_url, share_img_url, share_start_time) FROM stdin;
+2	scribbler|123	scribbler-sample-1.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/1.png	\N	2021-05-09 20:31:33
+3	scribbler|123	scribbler-sample-2.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/2.png	\N	2021-05-09 20:31:33
+4	scribbler|123	scribbler-sample-3.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621196923/scribbler-samples/3.png	\N	2021-05-09 20:31:33
+5	scribbler|123	scribbler-sample-4.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621210456/scribbler-samples/4.png	\N	2021-05-09 20:31:33
+6	scribbler|123	scribbler-sample-5.png	2021-05-09 20:31:33	https://res.cloudinary.com/carbonsoda/image/upload/v1621210678/scribbler-samples/5.png	\N	2021-05-09 20:31:33
 \.
 
 
@@ -140,7 +140,6 @@ COPY public.images (img_id, user_id, img_name, time_created, img_url) FROM stdin
 
 COPY public.users (id, username, user_id) FROM stdin;
 2	scribbler-demo	scribbler|123
-3	scribbler-user	auth0|60a197e2cbc3e700700e2352
 \.
 
 
@@ -192,7 +191,7 @@ ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_un UNIQUE (user_id);
 
 
--- Completed on 2021-05-20 14:50:24
+-- Completed on 2021-05-20 19:30:09
 
 --
 -- PostgreSQL database dump complete

--- a/server/db.mjs
+++ b/server/db.mjs
@@ -26,6 +26,19 @@ export const addUserImage = async (id, fileName, shareUrl, url24Hr) => db.any(
   [id, fileName, url24Hr, new Date(), shareUrl, new Date()],
 );
 
+export const getUserImgUrl = async (id, fileName) => db.one(
+  'SELECT share_img_url, share_start_time FROM images'
+  + ' WHERE user_id=($1) AND img_name=($2)',
+  [id, fileName],
+);
+
+export const updateUserImageUrl = async (id, fileName, newUrl) => db.none(
+  'UPDATE images SET share_img_url=($1), share_start_time=($2)'
+  + ' WHERE user_id=($3) AND img_name=($4)'
+  + ' RETURNING share_start_time',
+  [newUrl, new Date(), id, fileName],
+);
+
 export const createUser = async (user) => db.oneOrNone(
   'INSERT INTO users(username, user_id)'
   + ' VALUES ($1, $2)'

--- a/server/db.mjs
+++ b/server/db.mjs
@@ -32,8 +32,9 @@ export const getUserImgUrl = async (id, fileName) => db.one(
   [id, fileName],
 );
 
-export const updateUserImageUrl = async (id, fileName, newUrl) => db.none(
-  'UPDATE images SET share_img_url=($1), share_start_time=($2)'
+export const updateUserImageUrl = async (id, fileName, newUrl) => db.any(
+  'UPDATE images'
+  + ' SET share_img_url=($1), share_start_time=($2)'
   + ' WHERE user_id=($3) AND img_name=($4)'
   + ' RETURNING share_start_time',
   [newUrl, new Date(), id, fileName],

--- a/server/db.mjs
+++ b/server/db.mjs
@@ -5,25 +5,25 @@ import pgp from 'pg-promise';
 const db = initDb();
 
 export const getDemoImages = async (id) => db.any(
-  'SELECT img_id, img_name, img_url, time_created'
+  'SELECT img_id, img_name, card_img_url, time_created'
   + ' FROM images'
   + ' WHERE user_id=($1)',
   [id],
 );
 
 export const getUserImages = async (id) => db.any(
-  'SELECT img_id, img_name, img_url, time_created'
+  'SELECT img_id, img_name, card_img_url, time_created, share_img_url, share_start_time'
   + ' FROM images'
   + ' WHERE user_id=($1)'
   + ' AND time_created >= NOW() - INTERVAL \'24 HOURS\'',
   [id],
 );
 
-export const addUserImage = async (id, fileName, url) => db.any(
-  'INSERT INTO images(user_id, img_name, img_url, time_created)'
-  + ' VALUES ($1, $2, $3, $4)'
+export const addUserImage = async (id, fileName, shareUrl, url24Hr) => db.any(
+  'INSERT INTO images(user_id, img_name, card_img_url, time_created, share_img_url, share_start_time)'
+  + ' VALUES ($1, $2, $3, $4, $5, $6)'
   + ' RETURNING img_name',
-  [id, fileName, url, new Date()],
+  [id, fileName, url24Hr, new Date(), shareUrl, new Date()],
 );
 
 export const createUser = async (user) => db.oneOrNone(

--- a/server/routers/user.mjs
+++ b/server/routers/user.mjs
@@ -17,13 +17,15 @@ userRouter.post('/create', async (req, res) => {
 });
 
 userRouter.post('/upload', async (req, res) => {
-  const { fileName, user, url24Hr } = req.body;
+  const {
+    fileName, user, shareUrl, url24Hr,
+  } = req.body;
 
   // TODO: wrap in try/catch
   // undefined if user already exists
   await db.createUser(user);
 
-  const imgName = await db.addUserImage(user.sub, fileName, url24Hr);
+  const imgName = await db.addUserImage(user.sub, fileName, shareUrl, url24Hr);
 
   res.status(201).json({ imgName });
 });

--- a/server/routers/user.mjs
+++ b/server/routers/user.mjs
@@ -53,12 +53,12 @@ userRouter.get('/share-url', async (req, res) => {
 });
 
 userRouter.post('/share-url', async (req, res) => {
-  const { shareUrl, id, fileName } = req.body;
+  const { shareUrl, userId, fileName } = req.body;
 
   // eslint-disable-next-line camelcase
-  const { share_start_time } = await db.updateUserImageUrl(id, fileName, shareUrl);
+  const newStartTime = await db.updateUserImageUrl(userId, fileName, shareUrl);
 
-  res.json({ newStartTime: share_start_time });
+  res.json(newStartTime);
 });
 
 export default userRouter;

--- a/server/routers/user.mjs
+++ b/server/routers/user.mjs
@@ -43,4 +43,22 @@ userRouter.get('/history', async (req, res) => {
   res.json({ history });
 });
 
+userRouter.get('/share-url', async (req, res) => {
+  const { id, fileName } = req.query;
+
+  // eslint-disable-next-line camelcase
+  const { share_img_url, share_start_time } = await db.getUserImgUrl(id, fileName);
+
+  res.json({ imgUrl: share_img_url, startTime: share_start_time });
+});
+
+userRouter.post('/share-url', async (req, res) => {
+  const { shareUrl, id, fileName } = req.body;
+
+  // eslint-disable-next-line camelcase
+  const { share_start_time } = await db.updateUserImageUrl(id, fileName, shareUrl);
+
+  res.json({ newStartTime: share_start_time });
+});
+
 export default userRouter;


### PR DESCRIPTION
Registered users can refresh the sharable-link to their scribble! The refreshed url stays active for another 30 minutes.

Though, if the previously generated share-link is still active (aka it's been less than 30 min), then my app will just give the user that same one. This is so I can sorta limit how many AWS requests are made.

There is still a lot of styling work to be done, but at least this feature is fairly functional. [live-view](https://www.scribbler.dev/)